### PR TITLE
fix: add Firebase onValue listener cleanup to prevent resource leak

### DIFF
--- a/src/lib/pages/room/hooks/use-room-listener.ts
+++ b/src/lib/pages/room/hooks/use-room-listener.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { child, onDisconnect, onValue } from 'firebase/database';
+import { child, off, onDisconnect, onValue } from 'firebase/database';
 import { useParams, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { toaster } from '~/lib/components/ui/toaster';
 import { useUserRole } from '~/lib/hooks/use-user-role';
@@ -28,7 +28,6 @@ export const useRoomListener = () => {
 
   const params = useParams();
   const id = params?.id as string;
-  const firstRenderRef = useRef(true);
 
   const handleOnDisconnect = useCallback(() => {
     if (currentUser?.uid) {
@@ -38,9 +37,11 @@ export const useRoomListener = () => {
     }
   }, [currentUser?.uid, id]);
 
-  const getRoomData = useCallback(() => {
+  // Subscribe to room data -- cleaned up on unmount
+  useEffect(() => {
     setInRoom(true);
-    onValue(child(roomsData, id), (snap) => {
+
+    const unsubscribe = onValue(child(roomsData, id), (snap) => {
       if (snap.exists()) {
         setRoomData(snap.val());
         handleOnDisconnect();
@@ -52,6 +53,11 @@ export const useRoomListener = () => {
         });
       }
     });
+
+    return () => {
+      off(child(roomsData, id));
+      unsubscribe();
+    };
   }, [handleOnDisconnect, id, router, setInRoom, setRoomData]);
 
   const removeUserFromRoom = async () => {
@@ -65,13 +71,6 @@ export const useRoomListener = () => {
     await rejoinRoom(id, userRole);
     setInRoom(true);
   }, [id, setInRoom, userRole]);
-
-  useEffect(() => {
-    if (firstRenderRef.current) {
-      firstRenderRef.current = false;
-      getRoomData();
-    }
-  }, [getRoomData]);
 
   useEffect(() => {
     if (roomData && currentUser && inRoom) {
@@ -109,14 +108,13 @@ export const useRoomListener = () => {
       roomData &&
       currentUser &&
       inRoom &&
-      currentUser &&
-      roomData.users?.[currentUser?.uid] &&
-      !roomData.users?.[currentUser.uid]?.isConnected;
+      roomData.users?.[currentUser.uid] &&
+      !roomData.users[currentUser.uid]?.isConnected;
 
     if (inRoomDisconnected) {
       handleRejoin();
     }
-  }, [currentUser, handleRejoin, inRoom, roomData, roomData?.users]);
+  }, [currentUser, handleRejoin, inRoom, roomData]);
 
   // Handle route change - remove user from room when leaving
   // biome-ignore lint/correctness/useExhaustiveDependencies: cleanup function


### PR DESCRIPTION
## What Changed

Fixed a resource leak in `use-room-listener.ts` where the Firebase `onValue` subscription was never cleaned up.

### Problem
The original code wrapped `onValue()` inside a `useCallback` and called it from a `useEffect` guarded by a `firstRenderRef`. The subscription was never unsubscribed when the component unmounted or the room ID changed — creating a growing listener leak over time.

### Changes
1. **Added proper cleanup**: Inlined the `onValue` call into `useEffect` and return the unsubscribe function + `off()` in the cleanup
2. **Removed `firstRenderRef`**: No longer needed since the effect handles idempotency naturally
3. **Removed `useRef` import**: Unused after removing `firstRenderRef`
4. **Removed duplicate `currentUser` guard**: Was checked twice in the rejoin condition
5. **Fixed unnecessary optional chaining**: `currentUser?.uid` → `currentUser.uid` (already guarded by `currentUser` check)
6. **Cleaned dependency array**: Removed `roomData?.users` (redundant with `roomData`)

### Tradeoffs
- `off()` is called in addition to `unsubscribe()` for extra safety — this matches the recommended Firebase pattern
- No behavioral changes to the component logic

Created by: Eida (Hermes)